### PR TITLE
link builtins for android x86_64 targets

### DIFF
--- a/libsqlite3-sys/Cargo.toml
+++ b/libsqlite3-sys/Cargo.toml
@@ -48,3 +48,4 @@ bindgen = { version = "0.66", optional = true, default-features = false, feature
 pkg-config = { version = "0.3.19", optional = true }
 cc = { version = "1.0", optional = true }
 vcpkg = { version = "0.2", optional = true }
+glob = "0.3.1"

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -88,6 +88,7 @@ mod build_bundled {
     use std::env;
     use std::ffi::OsString;
     use std::path::{Path, PathBuf};
+    use glob::glob;
 
     use super::{is_compiler, win_target};
 
@@ -206,6 +207,26 @@ mod build_bundled {
         // https://android.googlesource.com/platform/external/sqlite/+/2c8c9ae3b7e6f340a19a0001c2a889a211c9d8b2/dist/Android.mk
         if super::android_target() {
             cfg.flag("-DSQLITE_TEMP_STORE=3");
+
+            // builtins for android-x86_64
+            let target = env::var("TARGET").unwrap();
+            if target == "x86_64-linux-android" {
+                // this might bork if building on os other than linux/macos, but I will leave that to those users to fix :)
+                let os = match env::consts::OS {
+                    "macos" => "darwin",
+                    os => os,
+                };
+                let ndk_home = env::var("ANDROID_NDK_HOME").expect("ANDROID_NDK_HOME not set");
+                let link_search_glob = format!("{}/toolchains/llvm/prebuilt/{}-x86_64/lib64/clang/**/lib/linux", ndk_home, os);
+                // there will be different version so just pick first, there likely shouldn't be multiple anyways
+                let link_search_path = glob(&link_search_glob)
+                    .expect("failed to read link_search_glob")
+                    .next()
+                    .expect("failed to find link_search_path")
+                    .expect("link_search_path glob result failed");
+                println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
+                println!("cargo:rustc-link-search={}", link_search_path.display());
+            }
         }
 
         if cfg!(feature = "with-asan") {

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -211,10 +211,11 @@ mod build_bundled {
             // builtins for android-x86_64
             let target = env::var("TARGET").unwrap();
             if target == "x86_64-linux-android" {
-                // this might bork if building on os other than linux/macos, but I will leave that to those users to fix :)
+                // this should work on linux, macos, and windows... don't think we would every build on others, bsd flavors might still work as linux... but not sure
                 let os = match env::consts::OS {
                     "macos" => "darwin",
-                    os => os,
+                    "windows" => "windows",
+                    _ => "linux",
                 };
                 let ndk_home = env::var("ANDROID_NDK_HOME").expect("ANDROID_NDK_HOME not set");
                 let link_search_glob = format!(

--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -85,10 +85,10 @@ fn main() {
     feature = "bundled-sqlcipher"
 ))]
 mod build_bundled {
+    use glob::glob;
     use std::env;
     use std::ffi::OsString;
     use std::path::{Path, PathBuf};
-    use glob::glob;
 
     use super::{is_compiler, win_target};
 
@@ -217,7 +217,10 @@ mod build_bundled {
                     os => os,
                 };
                 let ndk_home = env::var("ANDROID_NDK_HOME").expect("ANDROID_NDK_HOME not set");
-                let link_search_glob = format!("{}/toolchains/llvm/prebuilt/{}-x86_64/lib64/clang/**/lib/linux", ndk_home, os);
+                let link_search_glob = format!(
+                    "{}/toolchains/llvm/prebuilt/{}-x86_64/lib64/clang/**/lib/linux",
+                    ndk_home, os
+                );
                 // there will be different version so just pick first, there likely shouldn't be multiple anyways
                 let link_search_path = glob(&link_search_glob)
                     .expect("failed to read link_search_glob")


### PR DESCRIPTION
Applying the work around for android x86_64 compile failures. 
Uses glob to find correct directory without having to worry about the different versions of ndk included tools.
Should at very least work on linux and macos

This does require the ANDROID_NDK_HOME env variable to be set